### PR TITLE
Add a Network data type, that can be randomly generated

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,7 +1,5 @@
 module Main where
 
-import Lib
-
 import qualified Activation as A
 import qualified System.Random as S (mkStdGen)
 import qualified Matrix as M

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -7,6 +7,6 @@ import qualified Network as N
 import qualified Utils
 
 main :: IO ()
-main = 
-    -- print $ N.fromList [3, 2, 1] [A.ReLu, A.Sign] (S.mkStdGen 65498465465)
+main = do
+    print $ N.fromList [3, 2, 1] [A.ReLu, A.Sign] (S.mkStdGen 65498465465)
     print $ M.generate 2 4 (\(x, y) -> 4 * x + y)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -2,5 +2,13 @@ module Main where
 
 import Lib
 
+import qualified Activation as A
+import qualified System.Random as S (mkStdGen)
+import qualified Matrix as M
+import qualified Network as N
+import qualified Utils
+
 main :: IO ()
-main = someFunc
+main = do
+    print $ N.fromList [3, 2, 1] [A.ReLu, A.Sign] (S.mkStdGen 65498465465)
+    

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -7,4 +7,6 @@ import qualified Network as N
 import qualified Utils
 
 main :: IO ()
-main = print $ N.fromList [3, 2, 1] [A.ReLu, A.Sign] (S.mkStdGen 65498465465)
+main = 
+    -- print $ N.fromList [3, 2, 1] [A.ReLu, A.Sign] (S.mkStdGen 65498465465)
+    print $ M.generate 2 4 (\(x, y) -> 4 * x + y)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -8,5 +8,4 @@ import qualified Utils
 
 main :: IO ()
 main = do
-    print $ N.fromList [3, 2, 1] [A.ReLu, A.Sign] (S.mkStdGen 65498465465)
-    print $ M.generate 2 4 (\(x, y) -> 4 * x + y)
+    print $ N.fromList [3, 2, 1] [A.ReLu, A.Sign] (S.mkStdGen 123456)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -7,6 +7,4 @@ import qualified Network as N
 import qualified Utils
 
 main :: IO ()
-main = do
-    print $ N.fromList [3, 2, 1] [A.ReLu, A.Sign] (S.mkStdGen 65498465465)
-    
+main = print $ N.fromList [3, 2, 1] [A.ReLu, A.Sign] (S.mkStdGen 65498465465)

--- a/package.yaml
+++ b/package.yaml
@@ -51,5 +51,6 @@ tests:
     dependencies:
     - hspec
     - QuickCheck
+    - random
     - vector
     - yahnn

--- a/package.yaml
+++ b/package.yaml
@@ -25,7 +25,8 @@ dependencies:
 library:
   source-dirs: src
   dependencies:
-  - vector
+    - random 
+    - vector
 
 executables:
   yahnn-exe:
@@ -36,6 +37,7 @@ executables:
     - -rtsopts
     - -with-rtsopts=-N
     dependencies:
+    - random
     - yahnn
 
 tests:
@@ -47,7 +49,7 @@ tests:
     - -rtsopts
     - -with-rtsopts=-N
     dependencies:
-    - yahnn
     - hspec
     - QuickCheck
     - vector
+    - yahnn

--- a/src/Activation.hs
+++ b/src/Activation.hs
@@ -2,7 +2,7 @@ module Activation where
 
 import qualified Data.Vector as V (Vector(..))
 
-data Activation = ReLu | Sigmoid | Sign | TanH
+data Activation = ReLu | Sigmoid | Sign | TanH deriving (Show)
 
 activationForward :: (Real a) => Activation -> V.Vector a -> V.Vector a
 activationForward ReLu = fmap (\x -> if x < 0 then 0 else x)

--- a/src/Activation.hs
+++ b/src/Activation.hs
@@ -2,7 +2,7 @@ module Activation where
 
 import qualified Data.Vector as V (Vector(..))
 
-data Activation = ReLu | Sigmoid | Sign | TanH deriving (Show)
+data Activation = ReLu | Sigmoid | Sign | TanH deriving (Eq, Show)
 
 activationForward :: (Real a) => Activation -> V.Vector a -> V.Vector a
 activationForward ReLu = fmap (\x -> if x < 0 then 0 else x)

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -1,6 +1,0 @@
-module Lib
-    ( someFunc
-    ) where
-
-someFunc :: IO ()
-someFunc = putStrLn "someFunc"

--- a/src/Matrix.hs
+++ b/src/Matrix.hs
@@ -14,12 +14,11 @@ applyRow :: (V.Vector a -> b) -> Matrix a -> V.Vector b
 applyRow function = fmap function . toRows
 
 fromLayersList :: [Int] -> S.StdGen -> V.Vector (Matrix Double)
-fromLayersList  [] _ = V.empty
-fromLayersList (x:xs) generator
-    | null xs = V.empty
-    | otherwise =
-      let (vector, next_generator) = U.generateVector (x * head xs) generator
-      in Matrix x (head xs) vector `V.cons` fromLayersList xs next_generator
+fromLayersList [] _ = V.empty
+fromLayersList [x] _ = V.empty
+fromLayersList (x:y:xs) generator = Matrix x y randomVector `V.cons` fromLayersList xs generator
+  where
+    randomVector = U.generateVector (x * y) generator
 
 generate :: Int -> Int -> (Int -> a) -> Matrix a
 generate rows columns function = Matrix rows columns (V.generate (rows * columns) function)

--- a/src/Matrix.hs
+++ b/src/Matrix.hs
@@ -16,7 +16,7 @@ applyRow function = fmap function . toRows
 fromLayersList :: [Int] -> S.StdGen -> V.Vector (Matrix Double)
 fromLayersList [] _ = V.empty
 fromLayersList [x] _ = V.empty
-fromLayersList (x:y:xs) generator = Matrix x y randomVector `V.cons` fromLayersList xs generator
+fromLayersList (x:y:xs) generator = Matrix x y randomVector `V.cons` fromLayersList (y:xs) generator
   where
     randomVector = U.generateVector (x * y) generator
 

--- a/src/Matrix.hs
+++ b/src/Matrix.hs
@@ -20,9 +20,9 @@ fromLayersList (x:y:xs) generator = Matrix x y randomVector `V.cons` fromLayersL
   where
     randomVector = U.generateVector (x * y) generator
 
-generate :: Int -> Int -> (Int -> Int -> a) -> Matrix a
+generate :: Int -> Int -> ((Int, Int) -> a) -> Matrix a
 generate rows columns function =
-    Matrix rows columns $ V.generate (rows * columns) (\indice -> function (div indice columns) (mod indice columns))
+    Matrix rows columns $ V.generate (rows * columns) (\indice -> function (indice `div` columns, indice `mod` columns))
 
 multiplyVector :: (Real a) => Matrix a -> V.Vector a -> V.Vector a
 multiplyVector matrix vector

--- a/src/Matrix.hs
+++ b/src/Matrix.hs
@@ -1,16 +1,28 @@
 module Matrix where
 
-import Utils (chunksOf)
-import qualified Data.Vector as V (empty, Vector(..), zipWith)
+import qualified Utils as U (chunksOf, generateVector)
+import qualified Data.Vector as V (cons, empty, generate, replicate, Vector(..), zipWith)
+import qualified System.Random as S (randomR, StdGen(..))
 
 data Matrix a = Matrix {
     rows :: !Int,
     columns :: !Int,
     vector :: V.Vector a
-}
+} deriving (Show)
 
 applyRow :: (V.Vector a -> b) -> Matrix a -> V.Vector b
 applyRow function = fmap function . toRows
+
+fromLayersList :: [Int] -> S.StdGen -> V.Vector (Matrix Double)
+fromLayersList  [] _ = V.empty
+fromLayersList (x:xs) generator
+    | null xs = V.empty
+    | otherwise = do
+        let (vector, next_generator) = U.generateVector (x * (head xs)) generator
+        Matrix x (head xs) vector `V.cons` fromLayersList xs next_generator
+
+generate :: Int -> Int -> (Int -> a) -> Matrix a
+generate rows columns function = Matrix rows columns (V.generate (rows * columns) function)
 
 multiplyVector :: (Real a) => Matrix a -> V.Vector a -> V.Vector a
 multiplyVector matrix vector
@@ -18,4 +30,4 @@ multiplyVector matrix vector
     | otherwise = sum . V.zipWith (*) vector <$> toRows matrix
 
 toRows :: Matrix a -> V.Vector (V.Vector a)
-toRows (Matrix _ columns vector) = chunksOf columns vector
+toRows (Matrix _ columns vector) = U.chunksOf columns vector

--- a/src/Matrix.hs
+++ b/src/Matrix.hs
@@ -8,7 +8,7 @@ data Matrix a = Matrix {
     rows :: !Int,
     columns :: !Int,
     vector :: V.Vector a
-} deriving (Show)
+} deriving (Eq, Show)
 
 applyRow :: (V.Vector a -> b) -> Matrix a -> V.Vector b
 applyRow function = fmap function . toRows

--- a/src/Matrix.hs
+++ b/src/Matrix.hs
@@ -13,10 +13,10 @@ data Matrix a = Matrix {
 applyRow :: (V.Vector a -> b) -> Matrix a -> V.Vector b
 applyRow function = fmap function . toRows
 
-fromLayersList :: [Int] -> S.StdGen -> V.Vector (Matrix Double)
-fromLayersList [] _ = V.empty
-fromLayersList [x] _ = V.empty
-fromLayersList (x:y:xs) generator = Matrix x y randomVector `V.cons` fromLayersList (y:xs) subGenerator2
+fromLayersList :: [Int] -> S.StdGen -> [Matrix Double]
+fromLayersList [] _ = []
+fromLayersList [x] _ = []
+fromLayersList (x:y:xs) generator = Matrix x y randomVector : fromLayersList (y:xs) subGenerator2
   where
     (subGenerator1, subGenerator2) = S.split generator
     randomVector = U.generateVector (x * y) subGenerator1

--- a/src/Matrix.hs
+++ b/src/Matrix.hs
@@ -20,8 +20,9 @@ fromLayersList (x:y:xs) generator = Matrix x y randomVector `V.cons` fromLayersL
   where
     randomVector = U.generateVector (x * y) generator
 
-generate :: Int -> Int -> (Int -> a) -> Matrix a
-generate rows columns function = Matrix rows columns (V.generate (rows * columns) function)
+generate :: Int -> Int -> (Int -> Int -> a) -> Matrix a
+generate rows columns function =
+    Matrix rows columns $ V.generate (rows * columns) (\indice -> function (div indice columns) (mod indice columns))
 
 multiplyVector :: (Real a) => Matrix a -> V.Vector a -> V.Vector a
 multiplyVector matrix vector

--- a/src/Matrix.hs
+++ b/src/Matrix.hs
@@ -17,9 +17,9 @@ fromLayersList :: [Int] -> S.StdGen -> V.Vector (Matrix Double)
 fromLayersList  [] _ = V.empty
 fromLayersList (x:xs) generator
     | null xs = V.empty
-    | otherwise = do
-        let (vector, next_generator) = U.generateVector (x * (head xs)) generator
-        Matrix x (head xs) vector `V.cons` fromLayersList xs next_generator
+    | otherwise =
+      let (vector, next_generator) = U.generateVector (x * head xs) generator
+      in Matrix x (head xs) vector `V.cons` fromLayersList xs next_generator
 
 generate :: Int -> Int -> (Int -> a) -> Matrix a
 generate rows columns function = Matrix rows columns (V.generate (rows * columns) function)

--- a/src/Matrix.hs
+++ b/src/Matrix.hs
@@ -2,7 +2,7 @@ module Matrix where
 
 import qualified Utils as U (chunksOf, generateVector)
 import qualified Data.Vector as V (cons, empty, generate, replicate, Vector(..), zipWith)
-import qualified System.Random as S (randomR, StdGen(..))
+import qualified System.Random as S (StdGen(..), split)
 
 data Matrix a = Matrix {
     rows :: !Int,
@@ -16,9 +16,10 @@ applyRow function = fmap function . toRows
 fromLayersList :: [Int] -> S.StdGen -> V.Vector (Matrix Double)
 fromLayersList [] _ = V.empty
 fromLayersList [x] _ = V.empty
-fromLayersList (x:y:xs) generator = Matrix x y randomVector `V.cons` fromLayersList (y:xs) generator
+fromLayersList (x:y:xs) generator = Matrix x y randomVector `V.cons` fromLayersList (y:xs) subGenerator2
   where
-    randomVector = U.generateVector (x * y) generator
+    (subGenerator1, subGenerator2) = S.split generator
+    randomVector = U.generateVector (x * y) subGenerator1
 
 generate :: Int -> Int -> ((Int, Int) -> a) -> Matrix a
 generate rows columns function =

--- a/src/Network.hs
+++ b/src/Network.hs
@@ -8,7 +8,7 @@ import qualified System.Random as S (StdGen(..))
 data Network a = Network {
     activations :: [A.Activation],
     weights :: [M.Matrix a]
-} deriving (Show)
+} deriving (Eq, Show)
 
 fromList :: [Int] -> [A.Activation] -> S.StdGen -> Network Double
 fromList layers activations generator

--- a/src/Network.hs
+++ b/src/Network.hs
@@ -1,0 +1,16 @@
+module Network where
+
+import qualified Activation as A
+import qualified Data.Vector as V (empty, fromList, Vector(..))
+import qualified Matrix as M (fromLayersList, Matrix(..))
+import qualified System.Random as S (StdGen(..))
+
+data Network a = Network {
+    activations :: V.Vector A.Activation,
+    weights :: V.Vector (M.Matrix a)
+} deriving (Show)
+
+fromList :: [Int] -> [A.Activation] -> S.StdGen -> Network Double
+fromList layers activations generator
+--    | length layers /= length activations - 1 = Void
+    | otherwise = Network (V.fromList activations) (M.fromLayersList layers generator)

--- a/src/Network.hs
+++ b/src/Network.hs
@@ -6,11 +6,11 @@ import qualified Matrix as M (fromLayersList, Matrix(..))
 import qualified System.Random as S (StdGen(..))
 
 data Network a = Network {
-    activations :: V.Vector A.Activation,
-    weights :: V.Vector (M.Matrix a)
+    activations :: [A.Activation],
+    weights :: [M.Matrix a]
 } deriving (Show)
 
 fromList :: [Int] -> [A.Activation] -> S.StdGen -> Network Double
 fromList layers activations generator
 --    | length layers /= length activations - 1 = Void
-    | otherwise = Network (V.fromList activations) (M.fromLayersList layers generator)
+    | otherwise = Network activations (M.fromLayersList layers generator)

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -1,7 +1,7 @@
 module Utils where
 
-import qualified Data.Vector as V (cons, drop, empty, null, take, Vector(..))
-import qualified System.Random as S (randomR, StdGen(..))
+import qualified Data.Vector as V (cons, drop, empty, null, take, fromListN, Vector(..))
+import qualified System.Random as S (randomRs, StdGen(..))
 
 chunksOf :: Int -> V.Vector a -> V.Vector (V.Vector a)
 chunksOf length vector
@@ -9,10 +9,5 @@ chunksOf length vector
     | V.null vector = V.empty
     | otherwise = V.take length vector `V.cons` chunksOf length (V.drop length vector)
 
-generateVector :: Int -> S.StdGen -> (V.Vector Double, S.StdGen)
-generateVector length generator
-    | length <= 0 = (V.empty, generator)
-    | otherwise =
-        let (first, last) = S.randomR (-1.0, 1.0) generator
-            (vector, next_generator) = generateVector (length - 1) last
-        in (first `V.cons` vector, next_generator)
+generateVector :: Int -> S.StdGen -> V.Vector Double
+generateVector n = V.fromListN n . S.randomRs (-1.0, 1.0)

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -12,7 +12,7 @@ chunksOf length vector
 generateVector :: Int -> S.StdGen -> (V.Vector Double, S.StdGen)
 generateVector length generator
     | length <= 0 = (V.empty, generator)
-    | otherwise = do
+    | otherwise =
         let (first, last) = S.randomR (-1.0, 1.0) generator
-        let (vector, next_generator) = generateVector (length - 1) last
-        (first `V.cons` vector, next_generator)
+            (vector, next_generator) = generateVector (length - 1) last
+        in (first `V.cons` vector, next_generator)

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -1,9 +1,18 @@
 module Utils where
 
-import Data.Vector as V (cons, drop, empty, null, take, Vector(..))
+import qualified Data.Vector as V (cons, drop, empty, null, take, Vector(..))
+import qualified System.Random as S (randomR, StdGen(..))
 
 chunksOf :: Int -> V.Vector a -> V.Vector (V.Vector a)
 chunksOf length vector
     | length <= 0 = V.empty
     | V.null vector = V.empty
     | otherwise = V.take length vector `V.cons` chunksOf length (V.drop length vector)
+
+generateVector :: Int -> S.StdGen -> (V.Vector Double, S.StdGen)
+generateVector length generator
+    | length <= 0 = (V.empty, generator)
+    | otherwise = do
+        let (first, last) = S.randomR (-1.0, 1.0) generator
+        let (vector, next_generator) = generateVector (length - 1) last
+        (first `V.cons` vector, next_generator)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,6 +1,6 @@
 import Test.Hspec (describe, hspec, it, shouldBe)
 
-import Utils
+import qualified Utils
 import qualified Activation as A
 import qualified Matrix as M
 import qualified Data.Vector as V
@@ -37,4 +37,5 @@ testActivation = do
             A.activationForward A.Sign vector `shouldBe` V.fromList [-1, 1, 1, 1, -1, -1, 1, -1]
 
 main :: IO ()
-main = hspec $ testUtils >> testMatrix >> testActivation
+main = do
+    hspec $ testUtils >> testMatrix >> testActivation

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -7,7 +7,7 @@ import qualified Data.Vector as V
 
 vector = V.fromList [-2, 3, 6, 1, -8, -9, 3, -5]
 
-testUtils = do
+testUtils =
     describe "Test of utility functions:" $ do
         it "Chunks an empty vector" $
             chunksOf 5 (V.empty :: V.Vector Int) `shouldBe` V.empty
@@ -18,7 +18,7 @@ testUtils = do
 
 matrix = M.Matrix 2 4 vector
 
-testMatrix = do
+testMatrix =
     describe "Test of matrix functions:" $ do
         it "Sums rows" $
             M.applyRow sum matrix `shouldBe` V.fromList [8, -19]
@@ -27,7 +27,7 @@ testMatrix = do
         it "Multiplies vector with matching dimensions" $
             M.multiplyVector matrix (V.fromList [0, -6, 3, 1]) `shouldBe` V.fromList [1, 58]
 
-testActivation = do
+testActivation =
     describe "Test of activation functions:" $ do
         it "Forwards a ReLu activation" $
             A.activationForward A.ReLu vector `shouldBe` V.fromList [0, 3, 6, 1, 0, 0, 3, 0]
@@ -37,5 +37,5 @@ testActivation = do
             A.activationForward A.Sign vector `shouldBe` V.fromList [-1, 1, 1, 1, -1, -1, 1, -1]
 
 main :: IO ()
-main = do
+main =
     hspec $ testUtils >> testMatrix >> testActivation

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,6 +1,6 @@
 import Test.Hspec (describe, hspec, it, shouldBe)
 
-import qualified Utils
+import qualified Utils as U
 import qualified Activation as A
 import qualified Matrix as M
 import qualified Data.Vector as V
@@ -10,11 +10,11 @@ vector = V.fromList [-2, 3, 6, 1, -8, -9, 3, -5]
 testUtils =
     describe "Test of utility functions:" $ do
         it "Chunks an empty vector" $
-            chunksOf 5 (V.empty :: V.Vector Int) `shouldBe` V.empty
+            U.chunksOf 5 (V.empty :: V.Vector Int) `shouldBe` V.empty
         it "Even chunks a vector" $
-            chunksOf 2 vector `shouldBe` V.fromList (fmap V.fromList [[-2, 3], [6, 1], [-8, -9], [3, -5]])
+            U.chunksOf 2 vector `shouldBe` V.fromList (fmap V.fromList [[-2, 3], [6, 1], [-8, -9], [3, -5]])
         it "Uneven chunks a vector" $
-            chunksOf 3 vector `shouldBe` V.fromList (fmap V.fromList [[-2, 3, 6], [1, -8, -9], [3, -5]])
+            U.chunksOf 3 vector `shouldBe` V.fromList (fmap V.fromList [[-2, 3, 6], [1, -8, -9], [3, -5]])
 
 matrix = M.Matrix 2 4 vector
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,7 +1,6 @@
-import Test.Hspec (describe, hspec, it, shouldBe)
-
 import qualified Activation as A
 import qualified Data.Vector as V (empty, fromList, Vector(..))
+import qualified Test.Hspec as T (describe, hspec, it, shouldBe)
 import qualified Matrix as M
 import qualified Network as N
 import qualified System.Random as S (mkStdGen)
@@ -10,47 +9,47 @@ import qualified Utils as U
 vector = V.fromList [-2, 3, 6, 1, -8, -9, 3, -5]
 
 testUtils =
-    describe "Test of utility functions:" $ do
-        it "Chunks an empty vector" $
-            U.chunksOf 5 (V.empty :: V.Vector Int) `shouldBe` V.empty
-        it "Even chunks a vector" $
-            U.chunksOf 2 vector `shouldBe` V.fromList (fmap V.fromList [[-2, 3], [6, 1], [-8, -9], [3, -5]])
-        it "Uneven chunks a vector" $
-            U.chunksOf 3 vector `shouldBe` V.fromList (fmap V.fromList [[-2, 3, 6], [1, -8, -9], [3, -5]])
+    T.describe "Test of utility functions:" $ do
+        T.it"Chunks an empty vector" $
+            U.chunksOf 5 (V.empty :: V.Vector Int) `T.shouldBe` V.empty
+        T.it"Even chunks a vector" $
+            U.chunksOf 2 vector `T.shouldBe` V.fromList (fmap V.fromList [[-2, 3], [6, 1], [-8, -9], [3, -5]])
+        T.it"Uneven chunks a vector" $
+            U.chunksOf 3 vector `T.shouldBe` V.fromList (fmap V.fromList [[-2, 3, 6], [1, -8, -9], [3, -5]])
 
 matrix = M.Matrix 2 4 vector
 
 testMatrix =
-    describe "Test of matrix functions:" $ do
-        it "Sums rows" $
-            M.applyRow sum matrix `shouldBe` V.fromList [8, -19]
-        it "Multiplies vector with unmatching dimensions" $
-            M.multiplyVector matrix vector `shouldBe` V.empty
-        it "Multiplies vector with matching dimensions" $
-            M.multiplyVector matrix (V.fromList [0, -6, 3, 1]) `shouldBe` V.fromList [1, 58]
+    T.describe "Test of matrix functions:" $ do
+        T.it"Sums rows" $
+            M.applyRow sum matrix `T.shouldBe` V.fromList [8, -19]
+        T.it"Multiplies vector with unmatching dimensions" $
+            M.multiplyVector matrix vector `T.shouldBe` V.empty
+        T.it"Multiplies vector with matching dimensions" $
+            M.multiplyVector matrix (V.fromList [0, -6, 3, 1]) `T.shouldBe` V.fromList [1, 58]
 
 testActivation =
-    describe "Test of activation functions:" $ do
-        it "Forwards a ReLu activation" $
-            A.activationForward A.ReLu vector `shouldBe` V.fromList [0, 3, 6, 1, 0, 0, 3, 0]
-        it "Derivates a ReLu activation" $
-            A.activationDerivate A.ReLu vector `shouldBe` V.fromList [0, 1, 1, 1, 0, 0, 1, 0]
-        it "Forwards a Sign activation" $
-            A.activationForward A.Sign vector `shouldBe` V.fromList [-1, 1, 1, 1, -1, -1, 1, -1]
+    T.describe "Test of activation functions:" $ do
+        T.it"Forwards a ReLu activation" $
+            A.activationForward A.ReLu vector `T.shouldBe` V.fromList [0, 3, 6, 1, 0, 0, 3, 0]
+        T.it"Derivates a ReLu activation" $
+            A.activationDerivate A.ReLu vector `T.shouldBe` V.fromList [0, 1, 1, 1, 0, 0, 1, 0]
+        T.it"Forwards a Sign activation" $
+            A.activationForward A.Sign vector `T.shouldBe` V.fromList [-1, 1, 1, 1, -1, -1, 1, -1]
 
-generator = S.mkStdGen 123456
+generator = S.mkStdGen 12345
 
 testNetwork =
-    describe "Test of network functions:" $ do
-        it "Generates a random network" $
-            N.fromList [3, 2, 1] [A.ReLu, A.Sign] generator `shouldBe` N.Network [A.ReLu, A.Sign] [
-                M.Matrix 3 2 $ V.fromList [0.2677647642349532, -0.7475585300807475, -0.8720265567974974, -1.6527016918064907e-2, -0.3026656798412395, 0.35555427661286965],
-                M.Matrix 2 1 $ V.fromList [-0.7860612064870318, -0.34481051139882446]
+    T.describe "Test of network functions:" $ do
+        T.it"Generates a random network" $
+            N.fromList [3, 2, 1] [A.ReLu, A.Sign] generator `T.shouldBe` N.Network [A.ReLu, A.Sign] [
+                M.Matrix 3 2 $ V.fromList [1.9543818196252394e-2, -8.256066438750898e-2, 0.30326905954505934, 0.3728469630471347, -0.40816135066028125, -0.7351927684114008],
+                M.Matrix 2 1 $ V.fromList [9.31527772916203e-2, -4.6601584116810146e-2]
             ]
 
 main :: IO ()
 main =
-    hspec $
+    T.hspec $
         testUtils >>
         testMatrix >>
         testActivation >>

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,9 +1,11 @@
 import Test.Hspec (describe, hspec, it, shouldBe)
 
-import qualified Utils as U
 import qualified Activation as A
+import qualified Data.Vector as V (empty, fromList, Vector(..))
 import qualified Matrix as M
-import qualified Data.Vector as V
+import qualified Network as N
+import qualified System.Random as S (mkStdGen)
+import qualified Utils as U
 
 vector = V.fromList [-2, 3, 6, 1, -8, -9, 3, -5]
 
@@ -36,6 +38,20 @@ testActivation =
         it "Forwards a Sign activation" $
             A.activationForward A.Sign vector `shouldBe` V.fromList [-1, 1, 1, 1, -1, -1, 1, -1]
 
+generator = S.mkStdGen 123456
+
+testNetwork =
+    describe "Test of network functions:" $ do
+        it "Generates a random network" $
+            N.fromList [3, 2, 1] [A.ReLu, A.Sign] generator `shouldBe` N.Network [A.ReLu, A.Sign] [
+                M.Matrix 3 2 $ V.fromList [0.2677647642349532, -0.7475585300807475, -0.8720265567974974, -1.6527016918064907e-2, -0.3026656798412395, 0.35555427661286965],
+                M.Matrix 2 1 $ V.fromList [-0.7860612064870318, -0.34481051139882446]
+            ]
+
 main :: IO ()
 main =
-    hspec $ testUtils >> testMatrix >> testActivation
+    hspec $
+        testUtils >>
+        testMatrix >>
+        testActivation >>
+        testNetwork


### PR DESCRIPTION
This PR adds:

- A `Network` data type.
- A `fromList :: [Int] -> [A.Activation] -> S.StdGen -> Network Double` function to generate a network from a list of layers's size and a list of activations. The weights of the matrices are randomly generated between -1 and 1.
- Several functions in `Matrix` and `Utils` to allow such random generation.